### PR TITLE
Make list scrollable. Improve/add helper text.

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func main() {
 	}
 
 	m := initialModel(options)
-	p := tea.NewProgram(m)
+	p := tea.NewProgram(&m)
 	if err := p.Start(); err != nil {
 		log.Fatalf("Error: %v", err)
 	}


### PR DESCRIPTION
Fixes #2.

This PR:
- Makes the list scrollable using a `offset` based on the window height provided by `bubbletea`.
- Resets navigation when window is resized to prevent derps.
- Adds helper text containing number of hidden items.
- Improves navigation helper text, now showing all available key bindings.
- Adds a new key binding `d` to delete and leaves `q` as a quit-only option.