### PR TITLE
Add support for flags

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -1,0 +1,12 @@
+package main
+
+import "flag"
+
+var remote string
+var branch string
+
+func parseFlags() {
+	flag.StringVar(&remote, "remote", "origin", "Remote to fetch from")
+	flag.StringVar(&branch, "branch", "master", "Branch to compare against")
+	flag.Parse()
+}

--- a/git.go
+++ b/git.go
@@ -10,8 +10,6 @@ import (
 
 const mergedOption = "--merged"
 const noMergedOption = "--no-merged"
-const remote = "origin"
-const branch = "master"
 
 func gitBranch(merged bool) (branches []*Branch) {
 	option := noMergedOption

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func deleteBranches(selected []string) {
 }
 
 func main() {
+	parseFlags()
 	gitFetch()
 
 	branches := getBranches()


### PR DESCRIPTION
This PR adds support for command line flags (as defined in #6)
* `--remote <remote>` 
* `--branch <branch>`